### PR TITLE
Update gdal_chooseInstallation.R

### DIFF
--- a/R/gdal_chooseInstallation.R
+++ b/R/gdal_chooseInstallation.R
@@ -49,7 +49,7 @@ gdal_chooseInstallation <- function(hasDrivers)
 					} else
 					{
 						# FIX FOR VERSION 2.0						
-						matching_drivers <- grep(paste(hasDrivers,"-",sep=""),installation_drivers$format_code)
+						matching_drivers <- grep(paste0(hasDrivers,"-",collapse="|"),installation_drivers$format_code)
 						return(length(matching_drivers)==length(hasDrivers))
 					}				
 				},


### PR DESCRIPTION
I modified the line because the grep wasn't working due that 'grep' in some cases could take more than one pattern, I modified the grep to include "|" between pattern and that way should work with multiple patterns. I tested and works fine. 

Tested with 
> gdal_chooseInstallation(c("HDF4,"HDF5"))
[1]